### PR TITLE
[feat/#3] 이미지 업로드 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.649'
+	implementation'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/ImageEditSolutions/api_server/config/S3Config.java
+++ b/src/main/java/ImageEditSolutions/api_server/config/S3Config.java
@@ -1,0 +1,40 @@
+package ImageEditSolutions.api_server.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${aws.access.key}")
+    private String accessKey;
+
+    @Value("${aws.secret.key}")
+    private String secretKey;
+
+    @Value("${aws.region.static}")
+    private String region;
+
+    @Value("${aws.s3.bucket}")
+    private String bucketName;
+
+    @Bean
+    public AmazonS3 getAmazonS3Client() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey,secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .withRegion(region)
+                .build();
+    }
+
+    @Bean
+    public String bucketName() {
+        return bucketName;
+    }
+}

--- a/src/main/java/ImageEditSolutions/api_server/controller/ProjectController.java
+++ b/src/main/java/ImageEditSolutions/api_server/controller/ProjectController.java
@@ -1,0 +1,22 @@
+package ImageEditSolutions.api_server.controller;
+
+import ImageEditSolutions.api_server.dto.request.ProjectReqDto;
+import ImageEditSolutions.api_server.service.ProjectService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class ProjectController {
+    @Autowired
+    ProjectService projectService;
+
+    @PostMapping("/upload")
+    public ResponseEntity<String> saveProject(ProjectReqDto projectReqDto){
+        projectService.saveProject(projectReqDto);
+        return ResponseEntity.ok("프로젝트가 성공적으로 업로드되었습니다.");
+    }
+}

--- a/src/main/java/ImageEditSolutions/api_server/dto/request/ProjectReqDto.java
+++ b/src/main/java/ImageEditSolutions/api_server/dto/request/ProjectReqDto.java
@@ -1,0 +1,16 @@
+package ImageEditSolutions.api_server.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectReqDto {
+    private String uploadId;
+    private MultipartFile multipartFile;
+}

--- a/src/main/java/ImageEditSolutions/api_server/entity/Project.java
+++ b/src/main/java/ImageEditSolutions/api_server/entity/Project.java
@@ -1,0 +1,49 @@
+package ImageEditSolutions.api_server.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "projects")
+public class Project {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+
+    @Column(name = "upload_id")
+    private String uploadId;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public Project(String uploadId, String imageUrl) {
+        this.uploadId = uploadId;
+        this.imageUrl = imageUrl;
+    }
+
+}

--- a/src/main/java/ImageEditSolutions/api_server/global/CustomException.java
+++ b/src/main/java/ImageEditSolutions/api_server/global/CustomException.java
@@ -1,0 +1,10 @@
+package ImageEditSolutions.api_server.global;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException{
+    ErrorCode errorCode;
+}

--- a/src/main/java/ImageEditSolutions/api_server/global/CustomExceptionHandler.java
+++ b/src/main/java/ImageEditSolutions/api_server/global/CustomExceptionHandler.java
@@ -1,0 +1,13 @@
+package ImageEditSolutions.api_server.global;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class CustomExceptionHandler {
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ErrorResponseEntity> handleCustomException(CustomException e){
+        return ErrorResponseEntity.toResponseEntity(e.getErrorCode());
+    }
+}

--- a/src/main/java/ImageEditSolutions/api_server/global/ErrorCode.java
+++ b/src/main/java/ImageEditSolutions/api_server/global/ErrorCode.java
@@ -1,0 +1,21 @@
+package ImageEditSolutions.api_server.global;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    EMPTY_UPLOAD_ID(HttpStatus.BAD_REQUEST, "ACCOUNT-001", "업로드 아이디를 입력해주세요."),
+    UPLOAD_ID_ALREADY_EXISTS(HttpStatus.CONFLICT, "ACCOUNT-002", "이미 존재하는 아이디입니다."),
+
+    EMPTY_FILE(HttpStatus.BAD_REQUEST, "FILE-001","파일이 첨부되지 않았습니다."),
+    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST,"FILE-002", "잘못된 파일 형식입니다. 허용되는 파일 형식: jpg, jpeg, png, gif."),
+    FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-002", "파일 업로드 중 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/ImageEditSolutions/api_server/global/ErrorResponseEntity.java
+++ b/src/main/java/ImageEditSolutions/api_server/global/ErrorResponseEntity.java
@@ -1,0 +1,23 @@
+package ImageEditSolutions.api_server.global;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.http.ResponseEntity;
+
+@Data
+@Builder
+public class ErrorResponseEntity {
+    private int status;
+    private String code;
+    private String message;
+
+    public static ResponseEntity<ErrorResponseEntity> toResponseEntity(ErrorCode e){
+        return ResponseEntity
+                .status(e.getHttpStatus())
+                .body(ErrorResponseEntity.builder()
+                        .status(e.getHttpStatus().value())
+                        .code(e.getCode())
+                        .message(e.getMessage())
+                        .build());
+    }
+}

--- a/src/main/java/ImageEditSolutions/api_server/mapper/ProjectMapper.java
+++ b/src/main/java/ImageEditSolutions/api_server/mapper/ProjectMapper.java
@@ -1,0 +1,14 @@
+package ImageEditSolutions.api_server.mapper;
+
+import ImageEditSolutions.api_server.dto.request.ProjectReqDto;
+import ImageEditSolutions.api_server.entity.Project;
+
+public class ProjectMapper {
+
+    public static Project mapToProject(ProjectReqDto projectReqDto, String imageUrl) {
+        return new Project(
+                projectReqDto.getUploadId(),
+                imageUrl
+        );
+    }
+}

--- a/src/main/java/ImageEditSolutions/api_server/repository/ProjectRepository.java
+++ b/src/main/java/ImageEditSolutions/api_server/repository/ProjectRepository.java
@@ -1,0 +1,13 @@
+package ImageEditSolutions.api_server.repository;
+
+import ImageEditSolutions.api_server.entity.Project;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+    boolean existsByUploadId(String uploadId);
+
+}

--- a/src/main/java/ImageEditSolutions/api_server/service/ProjectService.java
+++ b/src/main/java/ImageEditSolutions/api_server/service/ProjectService.java
@@ -1,0 +1,7 @@
+package ImageEditSolutions.api_server.service;
+
+import ImageEditSolutions.api_server.dto.request.ProjectReqDto;
+
+public interface ProjectService {
+    void saveProject(ProjectReqDto projectReqDto);
+}

--- a/src/main/java/ImageEditSolutions/api_server/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/ImageEditSolutions/api_server/service/impl/ProjectServiceImpl.java
@@ -1,0 +1,107 @@
+package ImageEditSolutions.api_server.service.impl;
+
+import ImageEditSolutions.api_server.dto.request.ProjectReqDto;
+import ImageEditSolutions.api_server.entity.Project;
+import ImageEditSolutions.api_server.global.CustomException;
+import ImageEditSolutions.api_server.global.ErrorCode;
+import ImageEditSolutions.api_server.mapper.ProjectMapper;
+import ImageEditSolutions.api_server.repository.ProjectRepository;
+import com.amazonaws.services.s3.AmazonS3;
+import ImageEditSolutions.api_server.service.ProjectService;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@AllArgsConstructor
+public class ProjectServiceImpl implements ProjectService {
+    @Autowired
+    AmazonS3 s3Client;
+
+    @Autowired
+    private String bucketName;
+
+    private ProjectRepository projectRepository;
+
+    @Override
+    public void saveProject(ProjectReqDto projectReqDto) {
+        String uploadId = projectReqDto.getUploadId();
+        MultipartFile multipartFile = projectReqDto.getMultipartFile();
+
+    try{
+
+        // 업로드 아이디 null 체크
+        if (uploadId == null || uploadId.trim().isEmpty())
+           throw new CustomException(ErrorCode.EMPTY_UPLOAD_ID);
+
+        // 업로드 아이디 존재 여부 확인
+        if (projectRepository.existsByUploadId(uploadId)) {
+            throw new CustomException(ErrorCode. UPLOAD_ID_ALREADY_EXISTS);
+        }
+
+        // 파일 null 체크
+        if (multipartFile == null || multipartFile.isEmpty()) {
+            throw new CustomException(ErrorCode.EMPTY_FILE);
+        }
+
+        // 파일 확장자 확인
+        String fileName = multipartFile.getOriginalFilename();
+        if (fileName == null || !isValidExtension(fileName)) {
+            throw new CustomException(ErrorCode.INVALID_FILE_EXTENSION);
+        }
+
+        // 파일 이름 생성
+        String uniqueFileName = generateFileName(uploadId, multipartFile.getOriginalFilename());
+
+        // 파일 메타데이터 설정
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(multipartFile.getSize());
+        metadata.setContentType(multipartFile.getContentType());
+
+        // S3에 파일 업로드
+        s3Client.putObject(bucketName, uniqueFileName, multipartFile.getInputStream(), metadata);
+
+        // 업로드된 파일의 URL 생성
+        String imageUrl = s3Client.getUrl(bucketName, uniqueFileName).toString();
+
+        // 7. 프로젝트 엔티티 생성 및 DB 저장
+        Project project = ProjectMapper.mapToProject(projectReqDto, imageUrl);
+        projectRepository.save(project);
+        } catch (IOException e) {
+            // IOException 발생 시 예외 처리
+            throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
+        }
+    }
+
+    // 확장자 유효성 검사
+    private boolean isValidExtension(String fileName) {
+        // 확장자 유효성 검사용 리스트
+        List<String> validExtensions = Arrays.asList("jpg", "jpeg", "png", "gif");
+        // 파일명에서 마지막 '.' 의 위치를 찾음
+        int lastDotIndex = fileName.lastIndexOf(".");
+        // 파일 확장자가 존재하지 않으면 유효하지 않음
+        if (lastDotIndex == -1) {
+            return false;
+        }
+        // 확장자 추출
+        String extension = fileName.substring(lastDotIndex + 1).toLowerCase();
+        // 유효한 확장자인지 확인
+        return validExtensions.contains(extension);
+    }
+
+    // 파일 이름 생성
+    private String generateFileName(String uploadId, String originalFilename) {
+        int lastDotIndex = originalFilename.lastIndexOf(".");
+        String extension = originalFilename.substring(lastDotIndex);
+        return uploadId + "/" + UUID.randomUUID().toString() + extension;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,16 @@
 spring.application.name=api-server
+
+## AWS ##
+aws.s3.access-key=${AWS_ACCESS_KEY}
+aws.s3.secret-key=${AWS_SECRET_KEY}
+aws.region.static= ap-northeast-2
+aws.s3.bucket=smilelyawsbucket
+aws.stack.auto=false
+
+## PostgreSQL ##
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true


### PR DESCRIPTION
- [ ] #3 


1. AWS S3 연동

- 프로젝트 저장 시  이미지를Amazon S3에 업로드


2. 프로젝트 저장 기능

- 사용자가 업로드한 파일과 함께 프로젝트 이름 및 ID를 데이터베이스에 저장하는 기능을 추가


3. 커스텀 예외 처리

- CustomException 및 CustomExceptionHandler를 구현하여 오류 발생 시 사용자에게 명확한 메시지를 JSON 형식으로 반환하도록 처리

-  ErrorCode와 ErrorResponseEntity를 통해 다양한 오류 유형을 처리할 수 있도록 개선


4. DTO 및 Mapper 도입

- 프로젝트 생성 시 사용되는 DTO와 Mapper를 도입하여 코드의 재사용성과 가독성을 높임


close #3 