### PR TITLE
[fix/#11 ]AWS S3 통합 오류: IllegalArgumentException 처리

### DIFF
--- a/src/main/java/ImageEditSolutions/api_server/config/S3Config.java
+++ b/src/main/java/ImageEditSolutions/api_server/config/S3Config.java
@@ -3,6 +3,7 @@ package ImageEditSolutions.api_server.config;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
@@ -18,9 +19,6 @@ public class S3Config {
     @Value("${aws.secret.key}")
     private String secretKey;
 
-    @Value("${aws.region.static}")
-    private String region;
-
     @Value("${aws.s3.bucket}")
     private String bucketName;
 
@@ -29,7 +27,7 @@ public class S3Config {
         AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey,secretKey);
         return AmazonS3ClientBuilder.standard()
                 .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-                .withRegion(region)
+                .withRegion(Regions.AP_NORTHEAST_2)
                 .build();
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,6 @@ spring.application.name=api-server
 ## AWS ##
 aws.s3.access-key=${AWS_ACCESS_KEY}
 aws.s3.secret-key=${AWS_SECRET_KEY}
-aws.region.static= ap-northeast-2
 aws.s3.bucket=smilelyawsbucket
 aws.stack.auto=false
 


### PR DESCRIPTION
- [ ] #11 

1. 리전 설정
- S3 클라이언트의 리전을 AP_NORTHEAST_2로 지정하여 한국(서울) 리전에서의 사용을 설정

2. IllegalArgumentException 처리 
- AWS S3 통합 중 발생할 수 있는 IllegalArgumentException 에러를 방지하기 위해 유효한 호스트 이름 및 설정 검토

close #11 