### PR TITLE
[feat/#16] 명령프롬프트로 AI 이미지 생성

### DIFF
--- a/src/main/java/ImageEditSolutions/api_server/config/AppConfig.java
+++ b/src/main/java/ImageEditSolutions/api_server/config/AppConfig.java
@@ -1,0 +1,14 @@
+package ImageEditSolutions.api_server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/ImageEditSolutions/api_server/controller/ImageAIController.java
+++ b/src/main/java/ImageEditSolutions/api_server/controller/ImageAIController.java
@@ -1,0 +1,37 @@
+package ImageEditSolutions.api_server.controller;
+
+import ImageEditSolutions.api_server.service.ImageAIService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Base64;
+
+@RestController
+@RequestMapping("/image-ai")
+@RequiredArgsConstructor
+public class ImageAIController {
+
+    @Autowired
+    ImageAIService imageAIService;
+
+    @GetMapping
+    public ResponseEntity<List<String>> createImageAI(@RequestParam String prompt) {
+
+        // 이미지 생성
+        List<byte[]> images = imageAIService.createImageAI(prompt);
+
+        // Base64로 인코딩
+        List<String> base64Images = images.stream()
+                .map(img -> Base64.getEncoder().encodeToString(img))
+                .toList();
+
+        return ResponseEntity.ok(base64Images);
+    }
+
+}

--- a/src/main/java/ImageEditSolutions/api_server/controller/ImageAIController.java
+++ b/src/main/java/ImageEditSolutions/api_server/controller/ImageAIController.java
@@ -1,6 +1,10 @@
 package ImageEditSolutions.api_server.controller;
 
 import ImageEditSolutions.api_server.service.ImageAIService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,14 +17,18 @@ import java.util.List;
 import java.util.Base64;
 
 @RestController
-@RequestMapping("/image-ai")
 @RequiredArgsConstructor
+@RequestMapping("/image-ai")
+@Tag(name = "AI Image Management", description = "AI 이미지 생성 및 수정 관련 API")
 public class ImageAIController {
 
     @Autowired
     ImageAIService imageAIService;
 
     @GetMapping
+    @Operation(summary = "AI 이미지 생성하기")
+    @Parameter(name = "prompt", description = "생성할 이미지의 설명을 나타내는 문자열")
+    @ApiResponse(responseCode = "200", description = "AI 이미지 생성하기 성공")
     public ResponseEntity<List<String>> createImageAI(@RequestParam String prompt) {
 
         // 이미지 생성

--- a/src/main/java/ImageEditSolutions/api_server/controller/ProjectController.java
+++ b/src/main/java/ImageEditSolutions/api_server/controller/ProjectController.java
@@ -20,8 +20,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api")
-@Tag(name = "Response Estimate", description = "Response Estimate API")
+@Tag(name = "Project Management", description = "프로젝트 업로드 및 다운로드 관련 API")
 public class ProjectController {
+
     @Autowired
     ProjectService projectService;
 
@@ -44,4 +45,5 @@ public class ProjectController {
         ProjectResDto projectResDto = projectService.downloadProject(uploadId);
         return ResponseEntity.ok(projectResDto);
     }
+
 }

--- a/src/main/java/ImageEditSolutions/api_server/global/ErrorCode.java
+++ b/src/main/java/ImageEditSolutions/api_server/global/ErrorCode.java
@@ -14,7 +14,9 @@ public enum ErrorCode {
 
     EMPTY_FILE(HttpStatus.BAD_REQUEST, "FILE-001","파일이 첨부되지 않았습니다."),
     INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST,"FILE-002", "잘못된 파일 형식입니다. 허용되는 파일 형식: jpg, jpeg, png, gif."),
-    FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-003", "파일 업로드 중 오류가 발생했습니다.");
+    FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-003", "파일 업로드 중 오류가 발생했습니다."),
+
+    EMPTY_PROMPT(HttpStatus.BAD_REQUEST, "AI-001", "프롬프트를 입력해주세요.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/ImageEditSolutions/api_server/service/ImageAIService.java
+++ b/src/main/java/ImageEditSolutions/api_server/service/ImageAIService.java
@@ -1,0 +1,7 @@
+package ImageEditSolutions.api_server.service;
+
+import java.util.List;
+
+public interface ImageAIService {
+    List<byte[]> createImageAI(String text);
+}

--- a/src/main/java/ImageEditSolutions/api_server/service/impl/ImageAIServiceImpl.java
+++ b/src/main/java/ImageEditSolutions/api_server/service/impl/ImageAIServiceImpl.java
@@ -1,5 +1,7 @@
 package ImageEditSolutions.api_server.service.impl;
 
+import ImageEditSolutions.api_server.global.CustomException;
+import ImageEditSolutions.api_server.global.ErrorCode;
 import ImageEditSolutions.api_server.service.ImageAIService;
 import java.util.ArrayList;
 import lombok.AllArgsConstructor;
@@ -21,6 +23,12 @@ public class ImageAIServiceImpl implements ImageAIService {
 
     @Override
     public List<byte[]> createImageAI(String text) {
+
+        // 빈 값 체크
+        if (text == null || text.trim().isEmpty()) {
+            throw new CustomException(ErrorCode.EMPTY_PROMPT);
+        }
+
         List<byte[]> responses = new ArrayList<>();
 
         // 총 4개의 이미지를 생성하기 위해 반복문을 이용함

--- a/src/main/java/ImageEditSolutions/api_server/service/impl/ImageAIServiceImpl.java
+++ b/src/main/java/ImageEditSolutions/api_server/service/impl/ImageAIServiceImpl.java
@@ -1,0 +1,38 @@
+package ImageEditSolutions.api_server.service.impl;
+
+import ImageEditSolutions.api_server.service.ImageAIService;
+import java.util.ArrayList;
+import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class ImageAIServiceImpl implements ImageAIService {
+
+    // 이미지 생성 요청 URL
+    private static final String IMAGE_AI_URL = "https://image.pollinations.ai/prompt/";
+
+    @Autowired
+    RestTemplate restTemplate; // URL 주소로 요청을 보낼 수 있는 라이브러리
+
+    @Override
+    public List<byte[]> createImageAI(String text) {
+        List<byte[]> responses = new ArrayList<>();
+
+        // 총 4개의 이미지를 생성하기 위해 반복문을 이용함
+        for (int i = 0; i < 4; i++) {
+            byte[] response = restTemplate.getForEntity(
+                    IMAGE_AI_URL + text + i,
+                    byte[].class
+            ).getBody();
+            responses.add(response);
+        }
+
+        return responses;
+    }
+
+}


### PR DESCRIPTION
- [ ] #16 

1.  이미지 생성 API 구현
- ImageAIController 클래스에서 GET 요청을 처리하는 createImageAI 메서드 추가
- 사용자가 제공한 프롬프트를 사용하여 AI 이미지 생성
- 생성된 이미지를 Base64 문자열로 인코딩하여 반환

2. ImageAIService 인터페이스 정의
- ImageAIService 인터페이스와 그 구현체인 ImageAIServiceImpl을 추가하여 이미지 생성 로직을 분리

3. ImageAIServiceImpl 클래스 구현
- 이미지 생성 요청을 처리하는 createImageAI 메서드 추가
- 외부 API 호출을 위한 RestTemplate 사용
- createImageAI 메서드에 빈 프롬프트 체크 로직 추가
- 빈 값일 경우 CustomException을 던져 EMPTY_PROMPT 반환
- 총 4개의 이미지를 생성하기 위한 반복문 구현

4. Swagger 문서화 추가 및 태그 설정
- AI 이미지 생성 API에 Swagger @Tag 어노테이션 추가
- API 설명을 위한 @Operation 및 @Parameter 어노테이션 추가
- 성공적인 이미지 생성에 대한 응답 설명 추가

close #16 