### PR TITLE
[fix/#23] Translate API 호출 시 프롬프트 입력 오류 해결

### DIFF
--- a/src/main/java/ImageEditSolutions/api_server/controller/ImageAIController.java
+++ b/src/main/java/ImageEditSolutions/api_server/controller/ImageAIController.java
@@ -63,7 +63,6 @@ public class ImageAIController {
 
     @PostMapping("/translate")
     @Operation(summary = "텍스트 번역하기")
-    @Parameter(name = "prompt", description = "번역할 텍스트")
     @ApiResponse(responseCode = "200", description = "텍스트 번역하기 성공")
     public ResponseEntity<?> translate(@RequestBody Map<String, String> request){
 


### PR DESCRIPTION
- [ ] #23 

- Swagger 문서에서 `prompt` 파라미터 제거

close #23 