### PR TITLE
[feat/#27] 파일 업로드 최대 크기를 30MB로 설정

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,6 @@ deepl.api.key=${DEEPL_API_KEY}
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+
+spring.servlet.multipart.max-file-size=30MB
+spring.servlet.multipart.max-request-size=30MB


### PR DESCRIPTION
- [ ] #27 

1. application.properties 다음 설정을 추가
- spring.servlet.multipart.max-file-size를 30MB로 변경하여 단일 파일의 최대 크기를 증가
- spring.servlet.multipart.max-request-size를 30MB로 설정하여 요청에서 전송할 수 있는 총 파일 크기를 증가

close #27 