### PR TITLE
[Feat/#29]간단한 GET 요청에 대한 200 OK 응답 API 추가

### DIFF
--- a/src/main/java/ImageEditSolutions/api_server/controller/SimpleGetController.java
+++ b/src/main/java/ImageEditSolutions/api_server/controller/SimpleGetController.java
@@ -1,0 +1,19 @@
+package ImageEditSolutions.api_server.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "Simple Get", description = "단순 GET 요청에 대한 응답 API")
+public class SimpleGetController {
+    @GetMapping("/")
+    @Operation(summary = "단순 GET 요청 응답")
+    @ApiResponse(responseCode = "200", description = "OK 응답 반환")
+    public ResponseEntity<String> simpleGetResponse() {
+        return ResponseEntity.ok("OK");  // 200 OK 응답 반환
+    }
+}


### PR DESCRIPTION
- [ ] #29 

- / 경로로 GET 요청이 들어오면 200 OK 응답을 반환하는 API를 추가
- Swagger 설정을 통해 API에 대한 설명을 추가하고, 응답 코드와 메시지를 명시적으로 정의

close #29 