### PR TITLE
feat: 방 생성 및 입장 기능 구현

### DIFF
--- a/src/main/java/com/example/api_server/controller/RoomController.java
+++ b/src/main/java/com/example/api_server/controller/RoomController.java
@@ -1,0 +1,37 @@
+package com.example.api_server.controller;
+
+import com.example.api_server.dto.request.JoinRoomReqDto;
+import com.example.api_server.global.response.ResponseDto;
+import com.example.api_server.service.RoomService;
+import jakarta.validation.Valid;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/rooms")
+@RequiredArgsConstructor
+public class RoomController {
+
+    private final RoomService roomService;
+
+    // 방 만들기
+    @PostMapping
+    public ResponseEntity<ResponseDto<Map<String, Integer>>> createRoom(@RequestBody Map<String, Object> request) {
+        Long userId = Long.valueOf(request.get("userId").toString());
+        ResponseDto<Map<String, Integer>> response = roomService.createRoom(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 방 입장하기
+    @PostMapping("/join")
+    public ResponseEntity<ResponseDto<String>> joinRoom(@Valid @RequestBody JoinRoomReqDto joinRoomReqDto) {
+        ResponseDto response = roomService.joinRoom(joinRoomReqDto);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/example/api_server/dto/request/JoinRoomReqDto.java
+++ b/src/main/java/com/example/api_server/dto/request/JoinRoomReqDto.java
@@ -1,0 +1,20 @@
+package com.example.api_server.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class JoinRoomReqDto {
+
+    private Long userId;
+
+    @NotNull(message = "방 번호는 필수 입력값입니다.")
+    private Integer roomNumber;
+
+}

--- a/src/main/java/com/example/api_server/entity/Room.java
+++ b/src/main/java/com/example/api_server/entity/Room.java
@@ -1,0 +1,41 @@
+package com.example.api_server.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Room {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "room_id")
+    private Long roomId; // Primary Key
+
+    @Column(name = "user_id")
+    private Long userId; // 방 생성자의 ID
+
+    @Column(name = "room_number")
+    private Integer roomNumber; // 방 번호
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt; // 생성 시간
+
+    public Room(Long userId, Integer roomNumber) {
+        this.userId = userId;
+        this.roomNumber = roomNumber;
+    }
+}

--- a/src/main/java/com/example/api_server/entity/RoomParticipant.java
+++ b/src/main/java/com/example/api_server/entity/RoomParticipant.java
@@ -1,0 +1,48 @@
+package com.example.api_server.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class RoomParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "room_participant_id")
+    private Long roomParticipantId;
+
+    @Column(nullable = false)
+    private Long roomId; // 참여한 방 ID
+
+    @Column(nullable = false)
+    private Long userId; // 참여자 사용자 ID
+
+    @CreationTimestamp
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private LocalDateTime joinedAt = LocalDateTime.now(); // 방 참여 시간
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt; // 마지막 업데이트 시간
+
+    public RoomParticipant(Long roomId, Long userId){
+        this.roomId = roomId;
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/example/api_server/global/ErrorCode.java
+++ b/src/main/java/com/example/api_server/global/ErrorCode.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH-001", "아이디 또는 비밀번호를 잘못 입력했습니다."),
     DUPLICATE_USERNAME(HttpStatus.CONFLICT, "AUTH-002", "이미 존재하는 아이디입니다."),
-    EMPTY_USERNAME(HttpStatus.BAD_REQUEST, "AUTH-003", "아이디는 필수 입력값입니다.");
+    EMPTY_USERNAME(HttpStatus.BAD_REQUEST, "AUTH-003", "아이디는 필수 입력값입니다."),
+
+    ROOM_NOT_FOUND(HttpStatus.NOT_FOUND,"ROOM-001", "방을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus; // HTTP 상태 코드
     private final String code;           // 에러 코드

--- a/src/main/java/com/example/api_server/mapper/RoomMapper.java
+++ b/src/main/java/com/example/api_server/mapper/RoomMapper.java
@@ -1,0 +1,20 @@
+package com.example.api_server.mapper;
+
+import com.example.api_server.entity.Room;
+import com.example.api_server.entity.RoomParticipant;
+
+public class RoomMapper {
+    public static Room mapToRoom(Long userId, Integer roomNumber){
+        return new Room(
+                userId,       // 생성자의 userId
+                roomNumber  // 방 번호
+        );
+    }
+
+    public static RoomParticipant mapToRoomParticipant(Long roomId, Long userId){
+        return new RoomParticipant(
+                roomId,
+                userId
+        );
+    }
+}

--- a/src/main/java/com/example/api_server/repository/RoomParticipantRepository.java
+++ b/src/main/java/com/example/api_server/repository/RoomParticipantRepository.java
@@ -1,0 +1,10 @@
+package com.example.api_server.repository;
+
+import com.example.api_server.entity.RoomParticipant;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomParticipantRepository extends JpaRepository<RoomParticipant,Long> {
+
+    Optional<RoomParticipant> findByRoomIdAndUserId(Long roomId, Long userId);
+}

--- a/src/main/java/com/example/api_server/repository/RoomRepository.java
+++ b/src/main/java/com/example/api_server/repository/RoomRepository.java
@@ -1,0 +1,12 @@
+package com.example.api_server.repository;
+
+import com.example.api_server.entity.Room;
+import com.example.api_server.entity.RoomParticipant;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoomRepository extends JpaRepository<Room, Long>  {
+    Optional<Room> findByRoomNumber(Integer roomNumber);
+}

--- a/src/main/java/com/example/api_server/service/RoomService.java
+++ b/src/main/java/com/example/api_server/service/RoomService.java
@@ -1,0 +1,12 @@
+package com.example.api_server.service;
+
+import com.example.api_server.dto.request.JoinRoomReqDto;
+import com.example.api_server.global.response.ResponseDto;
+
+public interface RoomService {
+    // 방 만들기
+    ResponseDto createRoom(Long userId);
+
+    // 방 입장하기
+    ResponseDto joinRoom(JoinRoomReqDto joinRoomReqDto);
+}

--- a/src/main/java/com/example/api_server/service/impl/RoomServiceImpl.java
+++ b/src/main/java/com/example/api_server/service/impl/RoomServiceImpl.java
@@ -1,0 +1,87 @@
+package com.example.api_server.service.impl;
+
+import com.example.api_server.dto.request.JoinRoomReqDto;
+import com.example.api_server.entity.Room;
+import com.example.api_server.entity.RoomParticipant;
+import com.example.api_server.global.CustomException;
+import com.example.api_server.global.ErrorCode;
+import com.example.api_server.global.response.ResponseDto;
+import com.example.api_server.mapper.RoomMapper;
+import com.example.api_server.repository.RoomParticipantRepository;
+import com.example.api_server.repository.RoomRepository;
+import com.example.api_server.service.RoomService;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class RoomServiceImpl implements RoomService {
+
+    private final RoomRepository roomRepository;
+    private final RoomParticipantRepository roomParticipantRepository;
+
+    // 방 만들기
+    @Override
+    public ResponseDto<Map<String, Integer>> createRoom(Long userId) {
+
+        // 방 번호 생성
+        Integer roomNumber = generateRoomNumber();
+
+        // 새로운 방 생성 및 저장
+        Room room = RoomMapper.mapToRoom(userId, roomNumber);
+        roomRepository.save(room);
+
+        // RoomParticipant에 생성자 추가
+        RoomParticipant participant = RoomMapper.mapToRoomParticipant(
+                room.getRoomId(),
+                userId
+        );
+        roomParticipantRepository.save(participant);
+
+        // 응답 데이터 생성
+        Map<String, Integer> responseData = Map.of("roomNumber", roomNumber);
+
+        // ResponseDto로 성공 응답 생성
+        return ResponseDto.success(responseData);
+    }
+
+    // 방 입장하기
+    @Override
+    public  ResponseDto joinRoom(JoinRoomReqDto joinRoomReqDto) {
+        // 방 존재 여부 확인
+        Room room = roomRepository.findByRoomNumber(joinRoomReqDto.getRoomNumber())
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
+
+        // 방 참여자 데이터 조회
+        Optional<RoomParticipant> existingParticipant = roomParticipantRepository.findByRoomIdAndUserId(
+                room.getRoomId(), joinRoomReqDto.getUserId());
+
+        if (existingParticipant.isPresent()) {
+            // 이미 참여 중인 경우 updated_at 갱신
+            RoomParticipant participant = existingParticipant.get();
+            participant.setUpdatedAt(LocalDateTime.now());
+            roomParticipantRepository.save(participant);
+            return ResponseDto.success("참여 중인 방에 다시 연결");
+        }
+
+        // RoomParticipant에 사용자 추가
+        RoomParticipant participant = RoomMapper.mapToRoomParticipant(
+                room.getRoomId(),
+                joinRoomReqDto.getUserId()
+        );
+        roomParticipantRepository.save(participant);
+
+        return ResponseDto.success("방 입장 성공");
+    }
+
+    // 랜덤 방 번호 생성 메서드
+    private Integer generateRoomNumber() {
+        return (int) (Math.random() * 9000) + 1000; // 1000~9999 사이의 랜덤 숫자 생성
+    }
+
+}
+
+


### PR DESCRIPTION
- [x] #7 

**`구현 내용`**

1. 방 생성
- 방 생성 API 추가 (/rooms)
- 방 번호와 생성자를 입력받아 DB에 저장

2. 방 입장
- 방 입장 API 추가 (/rooms/join)
- 방 번호와 사용자 ID를 통해 방에 입장
- 이미 참여 중인 경우 updated_at 갱신
- 처음 입장 시 joined_at과 함께 참여자 정보 추가

3. 중복 방지 및 유효성 검증
- 방 번호와 사용자 ID를 기준으로 중복 확인
- 유효하지 않은 방 번호 요청 시 에러 반환

**`변경된 파일`**
- RoomController.java: 방 생성/입장 API 컨트롤러 추가
- RoomService.java: 서비스 인터페이스 정의
- RoomServiceImpl.java: 방 생성 및 입장 로직 구현
- Room.java: 방 엔티티 정의
- RoomParticipant.java: 참여자 엔티티 정의 및 타임스탬프 관리 (joined_at, updated_at)
- RoomMapper.java: DTO와 엔티티 매핑 추가
- RoomRepository.java: 방 조회 메서드 정의
- RoomParticipantRepository.java: 참여자 조회 및 중복 확인 메서드 정의
- JoinRoomReqDto.java: 방 입장 요청용 DTO 추가
- ErrorCode.java: 방 관련 에러 코드 추가 (ROOM_NOT_FOUND 등)

**`테스트`**
- Postman을 통해 방 생성 및 입장 API 테스트 완료
- DB에 방 및 참여자 데이터가 정상적으로 반영되는지 확인
- 중복 입장 시 업데이트만 수행되는지 확인

close #7 